### PR TITLE
Add SPDX taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ABNF syntax as per [RFC5234: Augmented BNF for Syntax Specifications: ABNF](http
 | `internal` | Namespace for internal use only. BOMs shared with 3rd parties SHOULD NOT include properties in the local namespace. | CycloneDX Core Working Group | N/A |
 | `aquasecurity` | Namespace for use by Aqua Security. | Aqua Security | `RESERVED` |
 | `dependency-track` | Namespace for use by the Dependency-Track project. | Dependency-Track Maintainers | `RESERVED` |
+| `spdx` | Namespace for inter-op with the SPDX format. | CycloneDX Core Working Group | [spdx taxonomy](spdx.md) |
 | `tern` | Namespace for use by the Tern project. | Tern Maintainers | [Tern Project](https://github.com/tern-tools/tern) |
 
 ## Registering New Top Level Namespaces

--- a/spdx.md
+++ b/spdx.md
@@ -1,0 +1,90 @@
+## `spdx` Namespace Taxonomy
+
+The SPDX namespaces and property names correspond to SPDX elements and fields.
+
+For more information on their meaning please refer to the [SPDX specification](https://spdx.github.io/spdx-spec/).
+
+| Namespace | Description |
+| --- | --- |
+| `spdx:checksum` | Checksum information |
+| `spdx:creation-info` | Creation information |
+| `spdx:document` | Document information |
+| `spdx:external-reference` | External reference information |
+| `spdx:file` | File information |
+| `spdx:package` | Package information |
+
+| Property |
+| --- |
+| `spdx:annotation` |
+| `spdx:comment` |
+| `spdx:download-location` |
+| `spdx:files-analyzed` |
+| `spdx:homepage` |
+| `spdx:license-comments` |
+| `spdx:license-concluded` |
+| `spdx:license-declared` |
+| `spdx:license-info-from-file` |
+| `spdx:spdxid` |
+
+## `spdx:checksum` Namespace Taxonomy
+
+| Property |
+| --- |
+| `spdx:checksum:md2` |
+| `spdx:checksum:md4` |
+| `spdx:checksum:md6` |
+| `spdx:checksum:sha225` |
+
+## `spdx:document` Namespace Taxonomy
+
+| Property |
+| --- |
+| `spdx:document:data-license` |
+| `spdx:document:describes` |
+| `spdx:document:document-namespace` |
+| `spdx:document:external-document-ref` |
+| `spdx:document:name` |
+| `spdx:document:spdx-version` |
+
+## `spdx:creation-info` Namespace Taxonomy
+
+| Property |
+| --- |
+| `spdx:creation-info:comment` |
+| `spdx:creation-info:creators-organization` |
+| `spdx:creation-info:license-list-version` |
+
+## `spdx:external-reference` Namespace Taxonomy
+
+| Property |
+| --- |
+| `spdx:external-reference:security:cpe22` |
+| `spdx:external-reference:security:cpe23` |
+| `spdx:external-reference:package-manager:bower` |
+| `spdx:external-reference:package-manager:maven-central` |
+| `spdx:external-reference:package-manager:npm` |
+| `spdx:external-reference:package-manager:nuget` |
+| `spdx:external-reference:package-manager:purl` |
+| `spdx:external-reference:persistent-id:swh` |
+| `spdx:external-reference:other` |
+
+## `spdx:file` Namespace Taxonomy
+
+| Property |
+| --- |
+| `spdx:file:type` |
+| `spdx:file:contributor` |
+| `spdx:file:notice-text` |
+
+## `spdx:package` Namespace Taxonomy
+
+| Property |
+| --- |
+| `spdx:package:file-name` |
+| `spdx:package:originator:email` |
+| `spdx:package:originator:organization` |
+| `spdx:package:source-info` |
+| `spdx:package:summary` |
+| `spdx:package:supplier:organization` |
+| `spdx:package:verification-code:value` |
+| `spdx:package:verification-code:excluded-file` |


### PR DESCRIPTION
This adds the property namespace taxonomy in use for CDX and SPDX inter-op in the CLI tool.

I've followed the namespace taxonomy recommendation that they _should_ be lower case. However, I think there might be a case here to not follow that.

As the aim of the `spdx` namespace is inter-op with the SPDX format, I think maybe it should follow SPDX conventions.

i.e. `spdx:package:summary`, should perhaps become `spdx:PackageSummary`, as that is what the tag is in the SPDX tag/value format.

I'm leaning towards consistency with SPDX tag/value format, as that will make it easier for people to find information about that field in the SPDX doco. Which I don't want to have to re-create here.