### PR TITLE
Add syft namespace for CycloneDX properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ABNF syntax as per [RFC5234: Augmented BNF for Syntax Specifications: ABNF](http
 | `aquasecurity` | Namespace for use by Aqua Security. | Aqua Security | `RESERVED` |
 | `dependency-track` | Namespace for use by the Dependency-Track project. | Dependency-Track Maintainers | `RESERVED` |
 | `spack` | Namespace for use by the Spack package manager. | Spack Maintainers | [Spack SBOM Project](https://github.com/spack/spack-sbom) |
+| `syft` | Namespace for use by the Syft project. | Syft Maintainers | [Syft Project](https://github.com/anchore/syft) |
 | `tern` | Namespace for use by the Tern project. | Tern Maintainers | [Tern Project](https://github.com/tern-tools/tern) |
 
 ## Registering New Top Level Namespaces


### PR DESCRIPTION
syft is currently using CycloneDX properties field for storing various custom values. This is a registration request to register a `syft` cyclonedx namespace.

cc: @luhring, @wagoodman, @spiffcs, @kzantow  to review this request before the CycloneDX core team reviews/merges this.

Fixes https://github.com/anchore/syft/issues/821