### PR TITLE
Correct Sonatype Taxonomy URL & Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the official CycloneDX property namespace and name taxonomy.
 With the v1.3 release of the specification, custom properties have been added.
 
 Although the specification doesn't impose restrictions on the property names used,
-standardization can assist tool implementors and BOM consumers.
+standardization can assist tool implementers and BOM consumers.
 
 The authoritative source of official namespaces and property names is this repository.
 
@@ -77,7 +77,7 @@ namespace SHOULD register a new top level namespace.
 The process for registering a new top level namespace is to
 [create a new issue requesting it](https://github.com/CycloneDX/cyclonedx-property-taxonomy/issues/new/choose).
 
-Namespaces are initialling registered as `RESERVED`.
+Namespaces are initially registered as `RESERVED`.
 
 Before using your `RESERVED` namespace, documentation for the taxonomy of the
 namespace SHOULD be publicly available. Failure to do so MAY result in the

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ interpreted as described in [RFC2119](http://www.ietf.org/rfc/rfc2119.txt).
 
 ## Namespace Syntax
 
-Namespaces are hierarchical and delimeted with a `:`.
+Namespaces are hierarchical and delimited with a `:`.
 
-As such, `:` MUST NOT be used in property namespaces and names except as a delimeter.
+As such, `:` MUST NOT be used in property namespaces and names except as a delimiter.
 
-The only characters that SHALL be used in official property namespaces and names are alpanumerical characters, "-", "_" and " " from the US ASCII character set.
+The only characters that SHALL be used in official property namespaces and names are alphanumerical characters, "-", "_" and " " from the US ASCII character set.
 
 Namespaces SHOULD be lower case. Base property names MAY use upper case.
 
@@ -64,7 +64,7 @@ ABNF syntax as per [RFC5234: Augmented BNF for Syntax Specifications: ABNF](http
 | `gitlab` | Namespace for use by GitLab. | GitLab | [GitLab taxonomy](https://gitlab.com/gitlab-org/security-products/gitlab-cyclonedx-property-taxonomy) |
 | `grype` | Namespace for use by the Grype project. | Grype Maintainers | [Grype Project](https://github.com/anchore/grype) |
 | `hoppr` | Namespace for the use by the Hoppr project. | Lockheed Martin | [hoppr taxonomy](https://hoppr.dev/architecture/cdx_taxonomy/) |
-| `sonatype` | Namespace for use by Sonatype | Sonatype | [Sonatype Taxonomy Documentation](https://help.sonatype.com/lift/open-source-vulnerability-analysis/dependency-view/cyclonedx-lift-namespace-taxonomy) |
+| `sonatype` | Namespace for use by Sonatype | Sonatype | [Sonatype Taxonomy Documentation](https://help.sonatype.com/lift/open-source-vulnerability-analysis/dependency-view/cyclonedx-sonatype-namespace-taxonomy) |
 | `spack` | Namespace for use by the Spack package manager. | Spack Maintainers | [Spack SBOM Project](https://github.com/spack/spack-sbom) |
 | `syft` | Namespace for use by the Syft project. | Syft Maintainers | [Syft Project](https://github.com/anchore/syft) |
 | `tern` | Namespace for use by the Tern project. | Tern Maintainers | [Tern Project](https://github.com/tern-tools/tern) |


### PR DESCRIPTION
* Update URL for Sonatype URL:  the target page has been renamed.
* Correct several spelling errors in README