### PR TITLE
add sub-namespace `cdx:npm` 

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -4,6 +4,7 @@
 | --- | --- | --- | --- |
 | `cdx:device` | Namespace for properties specific to hardware devices. | CycloneDX Core Working Group | [cdx:device taxonomy](cdx/device.md) |
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | CycloneDX Go Maintainers | [cdx:gomod taxonomy](cdx/gomod.md) |
+| `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | CycloneDX JavaScript Maintainers | [cdx:npm taxonomy](cdx/npm.md) |
 
 ## Registering `cdx` Namespaces and Properties
 

--- a/cdx/npm.md
+++ b/cdx/npm.md
@@ -1,0 +1,25 @@
+# `cdx:npm` Namespace Taxonomy
+
+| Namespace | Description |
+| --------- | ----------- |
+| `cdx:npm:package` | Namespace for package specific properties. |
+| `cdx:npm:package:constraint` | Namespace for package constraints. |
+
+_Boolean value_ are `true` or `false`. Case sensitive.
+
+## `cdx:npm:package` Namespace Taxonomy
+
+| Property | Description |
+| -------- | ----------- |
+| `cdx:npm:package:bundled` | Whether the package was bundled(shipped) with its parent component. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
+| `cdx:npm:package:extraneous` | Whether the package was installed extraneous. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
+| `cdx:npm:package:private` | Whether the package was flagged as "private". _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
+| `cdx:npm:package:development` | Whether the package was flagged as "devDependency". _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
+
+## `cdx:npm:package:constraint` Namespace Taxonomy
+
+| Property | Description |
+| -------- | ----------- |
+| `cdx:npm:package:constraint:engine:<NAME>` | Supported/required [engine marker](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines). May appear once. |
+| `cdx:npm:package:constraint:engine-strict` | Whether the engine is a requirement, or an advice. _Boolean value_.  If the property is missing, then assume the value to be `false`. May appear once. |
+| `cdx:npm:package:constraint:os` | Supported/required [operating system markers](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#os). May appear multiple times with different values. |


### PR DESCRIPTION
closes #20


## TODO 

checklist for myself: 

- [x] see https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/21#issuecomment-1207481279
   and https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/21#issuecomment-1207941916
- [x] validate if bundled dependencies are marked on their parent(root/cause) or on themself(effect)
  - npm flags components as  `inBundle` when they are bundled with their parent
