### PR TITLE
`cdx:npm:package:path`

### DIFF
--- a/cdx/npm.md
+++ b/cdx/npm.md
@@ -15,11 +15,12 @@ _Boolean value_ are `true` or `false`. Case sensitive.
 | `cdx:npm:package:extraneous` | Whether the package was installed extraneous. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
 | `cdx:npm:package:private` | Whether the package was flagged as "private". _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
 | `cdx:npm:package:development` | Whether the package was flagged as "devDependency". _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
+| `cdx:npm:package:path` | A path the package is installed to. Posix-like path representation relative to the root directory of the project under analysis. To represent the root dir, an empty string is used. May appear multiple times with different values. Example value: `node_modules/cliui/node_modules/strip-ansi` |
 
 ## `cdx:npm:package:constraint` Namespace Taxonomy
 
 | Property | Description |
 | -------- | ----------- |
-| `cdx:npm:package:constraint:engine:<NAME>` | Supported/required [engine marker](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines). May appear once. |
-| `cdx:npm:package:constraint:engine-strict` | Whether the engine is a requirement, or an advice. _Boolean value_.  If the property is missing, then assume the value to be `false`. May appear once. |
+| `cdx:npm:package:constraint:engine:<NAME>` | Supported/required [engine marker](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines). May appear once. Example: `cdx:npm:package:constraint:engine:node = >=12.2`|
+| `cdx:npm:package:constraint:engine-strict` | Whether the engine is a requirement, or an advice. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
 | `cdx:npm:package:constraint:os` | Supported/required [operating system markers](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#os). May appear multiple times with different values. |


### PR DESCRIPTION
caused by https://github.com/CycloneDX/cyclonedx-node-npm/issues/305

----

**NodeJS's module system is file-system based.** It works regardless of package dependencies, 
When code in module "foo" tries to use/require/access code from a different module "bar", then node will look in "foo";s own/direct "node_module" folder (depth 1). if it did not find any "bar" there, then  node traverses  all folders upwards and does the same lookup there,  until it finds any "bar".

This file-based loading behavior happens regardless of components' "dependency graph"
To make this loader-environment visible in an SBOM, a property should reflect a modules install path.

It could even happen that an SBOM's component is installed in multiple places. 
Therefore, a property should indicate all install locations. This meansthe property could appear multiple times with different values
This way it is possible to answer the question "is this component 'A' actually using component 'B1' or does it load 'B2' instead?"

An alternative would be to have the actual file tree represented as sub-components.
But component flattening or component de-duplication might change these prepared structures, which could lead to information loss.
So a property is preferred.

----

property value should be a representation of the install-path **relative** to the root directory of the project under analysis. 
no absolute paths, so private data (internal file path structures or mountpoints) are not published.


property value should be posix-like path, regardless of the actual runtime nor input nor detected path-patterns. 

to represent the same dir as the root dir, an empty string is expected.

----