### PR TITLE
feat: add `cdx:pipenv` namespace

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -6,8 +6,8 @@
 | `cdx:device` | Namespace for properties specific to hardware devices. | CycloneDX Core Working Group | [cdx:device taxonomy](cdx/device.md) |
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | CycloneDX Go Maintainers | [cdx:gomod taxonomy](cdx/gomod.md) |
 | `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | CycloneDX JavaScript Maintainers | [cdx:npm taxonomy](cdx/npm.md) |
-| `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | CycloneDX Python Maintainers | [cdx:poetry taxonomy](cdx/poetry.md) |
 | `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | CycloneDX Python Maintainers | [cdx:pipenv taxonomy](cdx/pipenv.md) |
+| `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | CycloneDX Python Maintainers | [cdx:poetry taxonomy](cdx/poetry.md) |
 
 ## Registering `cdx` Namespaces and Properties
 

--- a/cdx.md
+++ b/cdx.md
@@ -7,6 +7,7 @@
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | CycloneDX Go Maintainers | [cdx:gomod taxonomy](cdx/gomod.md) |
 | `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | CycloneDX JavaScript Maintainers | [cdx:npm taxonomy](cdx/npm.md) |
 | `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | CycloneDX Python Maintainers | [cdx:poetry taxonomy](cdx/poetry.md) |
+| `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | CycloneDX Python Maintainers | [cdx:pipenv taxonomy](cdx/pipenv.md) |
 
 ## Registering `cdx` Namespaces and Properties
 

--- a/cdx/pipenv.md
+++ b/cdx/pipenv.md
@@ -1,0 +1,11 @@
+# `cdx:pipenv` Namespace Taxonomy
+
+| Namespace | Description |
+| --------- | ----------- |
+| `cdx:pipenv:package` | Namespace for package specific properties. |
+
+## `cdx:pipenv:package` Namespace Taxonomy
+
+| Property | Description |
+| -------- | ----------- |
+| `cdx:pipenv:package:category` | Name of a [package category](https://pipenv.pypa.io/en/latest/basics/#specifying-package-categories) the component belongs to. Well-known groups are: "default", "develop". May appear multiple times with different values. |


### PR DESCRIPTION
As discussed with @jkowalleck - add `cdx:pipenv` namespace taxonomy to implement https://github.com/CycloneDX/cyclonedx-python/issues/474