### PR TITLE
docs: clarify namespace in ABNF

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,18 @@ Namespaces SHOULD be lower case. Base property names MAY use upper case.
 
 ### Examples
 
-```
+```text
 local:information_security_classification
 local:team_responsible
 ```
 
 ### ABNF for Official CycloneDX Property Names
 
-```
-property-name = 1*(namespace ":") name
+```ABNF
+property-name = namespace ":" name
 
 namespace     = 1*namechar
-
-name          = 1*namechar
+name          = 1*namechar [":" name]
 
 namechar      = ALPHA / DIGIT / "-" / "_" / " "
 ```


### PR DESCRIPTION
i found the docs confusing.

in the current ABNF it reads

```ABNF
property-name = 1*(namespace ":") name
; ...
```

the problem i saw: the namespace is used multiple time, so if i registered a namespace, how would i use it multiple times? 

Here is a fix.
