### PR TITLE
add cds:k8s taxonomy

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -8,6 +8,7 @@
 | `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | CycloneDX JavaScript Maintainers | [cdx:npm taxonomy](cdx/npm.md) |
 | `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | CycloneDX Python Maintainers | [cdx:pipenv taxonomy](cdx/pipenv.md) |
 | `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | CycloneDX Python Maintainers | [cdx:poetry taxonomy](cdx/poetry.md) |
+| `cdx:k8s` | Namespace for properties specific to the Kubernetes ecosystem. | CycloneDX Core Working Group | [cdx:k8s taxonomy](cdx/k8s.md) |
 
 ## Registering `cdx` Namespaces and Properties
 

--- a/cdx/k8s.md
+++ b/cdx/k8s.md
@@ -1,0 +1,11 @@
+## `cdx:k8s` Namespace Taxonomy
+
+| Namespace           | Description                                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `cdx:k8s:component` | Namespace for metadata of [Kubernetes components](https://kubernetes.io/docs/concepts/overview/components/). |
+
+## `cdx:k8s:component` Namespace Taxonomy
+
+| Property                 | Description                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `cdx:k8s:component:role` | Role of the Kubernetes component (api-server,kubelet,etc.)                                        |


### PR DESCRIPTION
Add `cdx:k8s` taxonomy. Motivation has been discussed in #59.

Comments:

1. I've decided to start simple and declare just one property that we actually need right now. I do expect us suggesting more fields in the future but to avoid premature definition, I thought it would be best to declare only what's implemented right now.
2. I've received some light feedback that `role` might be confused with "RBAC Role" in k8s context. 
    2.1 "type"/"kind" are ambiguous especially in this context.
    2.2 `cdx:components:component` is semantically most accurate but possibly less readable
    2.3 Overall I think role is fine, but happy feedback welcome.
3. `k8s` is commonly used (by the kubernetes community) to abbreviate `Kubernetes`, especially in use cases like this. LMK if you prefer `kubernetes` instaed.

Close: #54