### PR TITLE
init `cdx:maven` taxonomy with existing properties

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -11,6 +11,7 @@ _Boolean value_ are `true` or `false`. Case sensitive.
 | `cdx:composer` | Namespace for properties specific to the PHP Composer ecosystem. | CycloneDX PHP Maintainers | [cdx:composer taxonomy](cdx/composer.md) |
 | `cdx:device` | Namespace for properties specific to hardware devices. | CycloneDX Core Working Group | [cdx:device taxonomy](cdx/device.md) |
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | CycloneDX Go Maintainers | [cdx:gomod taxonomy](cdx/gomod.md) |
+| `cdx:maven` | Namespace for properties specific to the Maven plugin. | CycloneDX Maven Plugin Maintainers | [cdx:maven taxonomy](cdx/maven.md) |
 | `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | CycloneDX JavaScript Maintainers | [cdx:npm taxonomy](cdx/npm.md) |
 | `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | CycloneDX Python Maintainers | [cdx:pipenv taxonomy](cdx/pipenv.md) |
 | `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | CycloneDX Python Maintainers | [cdx:poetry taxonomy](cdx/poetry.md) |

--- a/cdx/maven.md
+++ b/cdx/maven.md
@@ -1,0 +1,14 @@
+# `cdx:maven` Namespace Taxonomy
+
+| Namespace | Description |
+| --------- | ----------- |
+| `cdx:maven:package` | Namespace for package specific properties. |
+
+## `cdx:maven:package` Namespace Taxonomy
+
+| Property | Description |
+| -------- | ----------- |
+| `cdx:maven:package:goal` | The goal used to generate the SBOM: `makeBom`, `makeAggregateBom` or `makePackageBom`. |
+| `cdx:maven:package:scopes` | The activated Maven dependency scopes: `compile`, `provided`, `runtime`, `system` or `test`, comma-separated if many. |
+| `cdx:maven:package:reproducible` | Whether the SBOM has been generated in Reproducible Builds mode: in this mode, metadata timestamp and BOM serial number are dropped. _Boolean value_. If the property is missing, then assume the value to be `false`. |
+| `cdx:maven:package:optional-unused` | Use bytecode analysis instead of Maven dependency declaration of optional to define SBOM OPTIONAL or REQUIRED scope. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |

--- a/cdx/maven.md
+++ b/cdx/maven.md
@@ -12,5 +12,4 @@ _Boolean value_ are `true` or `false`. Case insensitive.
 | -------- | ----------- |
 | `cdx:maven:package:goal` | The goal used to generate the SBOM: `makeBom`, `makeAggregateBom` or `makePackageBom`. May appear once. |
 | `cdx:maven:package:scope` | An activated Maven dependency scope: `compile`, `provided`, `runtime`, `system` or `test`. |
-| `cdx:maven:package:reproducible` | Whether the SBOM has been generated in Reproducible Builds mode: in this mode, metadata timestamp and BOM serial number are dropped. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
 | `cdx:maven:package:optional-unused` | Use bytecode analysis instead of Maven dependency declaration of optional to define SBOM OPTIONAL or REQUIRED scope. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |

--- a/cdx/maven.md
+++ b/cdx/maven.md
@@ -10,6 +10,9 @@ _Boolean value_ are `true` or `false`. Case insensitive.
 
 | Property | Description |
 | -------- | ----------- |
-| `cdx:maven:package:goal` | The goal used to generate the SBOM: `makeBom`, `makeAggregateBom` or `makePackageBom`. May appear once. |
-| `cdx:maven:package:scope` | An activated Maven dependency scope: `compile`, `provided`, `runtime`, `system` or `test`. |
+| `cdx:maven:package:goal` | The [goal] used to generate the SBOM: `makeBom`, `makeAggregateBom` or `makePackageBom`. May appear once. |
+| `cdx:maven:package:scope` | An activated Maven [dependency scope]: `compile`, `provided`, `runtime`, `system` or `test`. |
 | `cdx:maven:package:optional-unused` | Use bytecode analysis instead of Maven dependency declaration of optional to define SBOM OPTIONAL or REQUIRED scope. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
+
+[goal]: https://github.com/CycloneDX/cyclonedx-maven-plugin#goals
+[dependency scope]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope

--- a/cdx/maven.md
+++ b/cdx/maven.md
@@ -4,11 +4,13 @@
 | --------- | ----------- |
 | `cdx:maven:package` | Namespace for package specific properties. |
 
+_Boolean value_ are `true` or `false`. Case insensitive.
+
 ## `cdx:maven:package` Namespace Taxonomy
 
 | Property | Description |
 | -------- | ----------- |
-| `cdx:maven:package:goal` | The goal used to generate the SBOM: `makeBom`, `makeAggregateBom` or `makePackageBom`. |
-| `cdx:maven:package:scopes` | The activated Maven dependency scopes: `compile`, `provided`, `runtime`, `system` or `test`, comma-separated if many. |
-| `cdx:maven:package:reproducible` | Whether the SBOM has been generated in Reproducible Builds mode: in this mode, metadata timestamp and BOM serial number are dropped. _Boolean value_. If the property is missing, then assume the value to be `false`. |
+| `cdx:maven:package:goal` | The goal used to generate the SBOM: `makeBom`, `makeAggregateBom` or `makePackageBom`. May appear once. |
+| `cdx:maven:package:scope` | An activated Maven dependency scope: `compile`, `provided`, `runtime`, `system` or `test`. |
+| `cdx:maven:package:reproducible` | Whether the SBOM has been generated in Reproducible Builds mode: in this mode, metadata timestamp and BOM serial number are dropped. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |
 | `cdx:maven:package:optional-unused` | Use bytecode analysis instead of Maven dependency declaration of optional to define SBOM OPTIONAL or REQUIRED scope. _Boolean value_. If the property is missing, then assume the value to be `false`. May appear once. |


### PR DESCRIPTION
fixes #68 with existing properties added in cyclonedx-maven-plugin 2.7.7 and 2.7.9
once this is done, we'll add new properties later