### PR TITLE
add property `cdx:reproducible`

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -1,7 +1,13 @@
-## `cdx` Namespace Taxonomy
+# `cdx` Namespace Taxonomy
+
+_Boolean value_ are `true` or `false`. Case sensitive.
+
+| Property | Description |
+| -------- | ----------- |
+| `cdx:reproducible` | Whether the CycloneDX document has been generated in a reproducible manner: if so, then time- or random-based values MUST be omitted, and elements order SHOULD be reproducible. _Boolean value_. May appear once. |
 
 | Namespace | Description | Administered By | Taxonomy |
-| --- | --- | --- | --- |
+| --------- | ----------- | --------------- | -------- |
 | `cdx:composer` | Namespace for properties specific to the PHP Composer ecosystem. | CycloneDX PHP Maintainers | [cdx:composer taxonomy](cdx/composer.md) |
 | `cdx:device` | Namespace for properties specific to hardware devices. | CycloneDX Core Working Group | [cdx:device taxonomy](cdx/device.md) |
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | CycloneDX Go Maintainers | [cdx:gomod taxonomy](cdx/gomod.md) |


### PR DESCRIPTION
Purpose: flag a SBOM document or parts of it as reproducible.
reproducible SBOMs usually omit time-and random-based information, and might render elements in a reproducible order.

some implementations that can generate “reproducible” BOMs, by omitting time- and random-based values, ordering elements, and so on already exist. 

- https://github.com/CycloneDX/cyclonedx-maven-plugin
- https://github.com/CycloneDX/cyclonedx-php-composer
- https://github.com/CycloneDX/cyclonedx-webpack-plugin
- https://github.com/CycloneDX/cyclonedx-node-npm


caused by https://github.com/CycloneDX/cyclonedx-property-taxonomy/pull/69#issuecomment-1667631922