### PR TITLE
revisit/maintain registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+# CycloneDX Property Taxonomy
+
 [![License](https://img.shields.io/badge/license-apache%20v2-brightgreen.svg)](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/master/LICENSE)
 [![Website](https://img.shields.io/badge/https://-cyclonedx.org-blue.svg)](https://cyclonedx.org/)
 [![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack&labelColor=393939)](https://cyclonedx.org/slack/invite)
 [![Group Discussion](https://img.shields.io/badge/discussion-groups.io-blue.svg)](https://groups.io/g/CycloneDX)
 [![Twitter](https://img.shields.io/twitter/url/http/shields.io.svg?style=social&label=Follow)](https://twitter.com/CycloneDX_Spec)
-
-# CycloneDX Property Taxonomy
 
 This is the official CycloneDX property namespace and name taxonomy.
 
@@ -34,8 +34,8 @@ Namespaces SHOULD be lower case. Base property names MAY use upper case.
 ### Examples
 
 ```text
-local:information_security_classification
-local:team_responsible
+internal:information_security_classification
+internal:team_responsible
 ```
 
 ### ABNF for Official CycloneDX Property Names
@@ -56,36 +56,36 @@ ABNF syntax as per [RFC5234: Augmented BNF for Syntax Specifications: ABNF](http
 
 | Namespace | Description | Administered By | Taxonomy |
 | --- | --- | --- | --- |
-| `cdx` | Namespace for official CycloneDX namespaces and properties. Unofficial namespaces and properties MUST NOT be used under the `cdx` namespace. | CycloneDX Core Working Group | [cdx taxonomy](cdx.md) |
-| `internal` | Namespace for internal use only. BOMs shared with 3rd parties SHOULD NOT include properties in the local namespace. | CycloneDX Core Working Group | N/A |
+| `cdx` | Namespace for official CycloneDX namespaces and properties. Unofficial namespaces and properties MUST NOT be used under the `cdx` namespace. | [CycloneDX Core Working Group](https://github.com/orgs/CycloneDX) | [cdx taxonomy](cdx.md) |
+| `internal` | Namespace for internal use only. BOMs shared with 3rd parties SHOULD NOT include properties in this namespace. | N/A | N/A |
 | `urn` | Namespace blocked to prevent confusions with [Uniform Resource Name](https://www.rfc-editor.org/rfc/rfc2141) | N/A | N/A |
-| `aboutcode` | Namespace for use by AboutCode projects. | nexB | [AboutCode taxonomy](https://github.com/nexB/aboutcode-cyclonedx-taxonomy#readme) |
-| `amazon` | Namespace for use by Amazon. | Amazon | `RESERVED` |
-| `appknox` | Namespace for use by Appknox Platform. | Appknox | [Appknox taxonomy](https://github.com/appknox/cyclonedx-property-taxonomy#readme) |
-| `aquasecurity` | Namespace for use by Aqua Security. | Aqua Security | `RESERVED` |
-| `boschrexroth` | Namespace for use by Bosch Rexroth. | Bosch Rexroth AG | [Bosch Rexroth taxonomy](https://github.com/boschrexroth/cyclonedx-property-taxonomy#readme) |
-| `bytetrail` | Namespace for use by ByteTrail. | ByteTrail | `RESERVED` | 
-| `codenotary` | Namespace for use by Codenotary platform. | Codenotary | [Codenotary taxonomy](https://github.com/codenotary/cyclonedx-property-taxonomy) |
-| `dependency-track` | Namespace for use by the Dependency-Track project. | Dependency-Track Maintainers | `RESERVED` |
-| `expliot` | Namespace for use by EXPLIoT. | EXPLIoT | [EXPLIoT taxonomy](https://gitlab.com/expliot_framework/expliot/-/blob/master/docs/compliance/cyclonedx.rst) |
-| `finitestate` | Namespace for the use by Finite State. | Finite State | [finitestate taxonomy](https://github.com/FiniteStateInc/cyclonedx-property-taxonomy#readme) |
-| `fortify` | Namespace for use by Fortify. | Micro Focus | `RESERVED` |
-| `gitlab` | Namespace for use by GitLab. | GitLab | [GitLab taxonomy](https://docs.gitlab.com/ee/development/sec/cyclonedx_property_taxonomy.html) |
-| `grype` | Namespace for use by the Grype project. | Grype Maintainers | [Grype Project](https://github.com/anchore/grype) |
-| `hoppr` | Namespace for the use by the Hoppr project. | Lockheed Martin | [Hoppr Project](https://hoppr.dev/docs/architecture/cdx-taxonomy/) |
-| `ibm` | Namespace for use by IBM. | IBM | `RESERVED` |
-| `ksoc` | Namespace for use by KSOC. | KSOC | [KSOC taxonomy](https://github.com/ksoclabs/kbom/blob/main/docs/taxonomy.md) |
-| `medical-aegis` | Namespace for use by Medical Aegis. | Medical Aegis | `RESERVED` |
-| `recon` | Namespace for use by the Recon Project. | Recon Project | `RESERVED` |
-| `servicenow` | Namespace for use by ServiceNow. | ServiceNow | `RESERVED` |
-| `siemens` | Namespace for use by Siemens. | Siemens | [Siemens taxonomy](https://github.com/siemens/cyclonedx-property-taxonomy#readme) |
-| `snyk` | Namespace for use by Snyk. | Snyk | [Snyk Taxonomy Documentation](https://docs.snyk.io/snyk-api-info/get-a-projects-sbom-document-endpoint#custom-cyclonedx-properties) |
-| `sonatype` | Namespace for use by Sonatype | Sonatype | [Sonatype Taxonomy Documentation](https://help.sonatype.com/lift/open-source-vulnerability-analysis/dependency-view/cyclonedx-sonatype-namespace-taxonomy) |
+| `aboutcode` | Namespace for use by AboutCode projects. | [nexB](https://github.com/nexB) | [AboutCode taxonomy](https://github.com/nexB/aboutcode-cyclonedx-taxonomy#readme) |
+| `amazon` | Namespace for use by Amazon. | [Amazon](https://github.com/amzn) | `RESERVED` |
+| `appknox` | Namespace for use by Appknox Platform. | [Appknox](https://github.com/appknox) | [Appknox taxonomy](https://github.com/appknox/cyclonedx-property-taxonomy#readme) |
+| `aquasecurity` | Namespace for use by Aqua Security. | [Aqua Security](https://github.com/aquasecurity) | `RESERVED` |
+| `boschrexroth` | Namespace for use by Bosch Rexroth. | [Bosch Rexroth AG](https://github.com/boschrexroth) | [Bosch Rexroth taxonomy](https://github.com/boschrexroth/cyclonedx-property-taxonomy#readme) |
+| `bytetrail` | Namespace for use by ByteTrail. | [ByteTrail](https://github.com/bytetrail) | `RESERVED` |
+| `codenotary` | Namespace for use by Codenotary platform. | [Codenotary](https://github.com/codenotary) | [Codenotary taxonomy](https://github.com/codenotary/cyclonedx-property-taxonomy) |
+| `dependency-track` | Namespace for use by the Dependency-Track project. | [Dependency-Track Maintainers](https://github.com/DependencyTrack) | `RESERVED` |
+| `expliot` | Namespace for use by EXPLIoT. | [EXPLIoT](https://gitlab.com/expliot_framework) | [EXPLIoT taxonomy](https://gitlab.com/expliot_framework/expliot/-/blob/master/docs/compliance/cyclonedx.rst) |
+| `finitestate` | Namespace for the use by Finite State. | [Finite State](https://github.com/FiniteStateInc) | [finitestate taxonomy](https://github.com/FiniteStateInc/cyclonedx-property-taxonomy#readme) |
+| `fortify` | Namespace for use by Fortify. | [Micro Focus](https://github.com/MicroFocus) | `RESERVED` |
+| `gitlab` | Namespace for use by GitLab. | [GitLab](https://gitlab.com) | [GitLab taxonomy](https://docs.gitlab.com/ee/development/sec/cyclonedx_property_taxonomy.html) |
+| `grype` | Namespace for use by the Grype project. | [Grype Maintainers](https://github.com/anchore/grype) | `RESERVED` |
+| `hoppr` | Namespace for the use by the Hoppr project. | [Lockheed Martin](https://hoppr.dev/) |
+| `ibm` | Namespace for use by IBM. | [IBM](https://github.com/IBM) | `RESERVED` |
+| `ksoc` | Namespace for use by KSOC. | [KSOC](https://github.com/ksoclabs) | [KSOC taxonomy](https://github.com/ksoclabs/kbom/blob/main/docs/taxonomy.md) |
+| `medical-aegis` | Namespace for use by Medical Aegis. | [Medical Aegis](https://github.com/Medical-Aegis) | `RESERVED` |
+| `recon` | Namespace for use by the Recon Project. | [Recon Project](https://github.com/rusty-ferris-club/recon) | `RESERVED` |
+| `servicenow` | Namespace for use by ServiceNow. | [ServiceNow](https://github.com/ServiceNow) | `RESERVED` |
+| `siemens` | Namespace for use by Siemens. | [Siemens](https://github.com/siemens) | [Siemens taxonomy](https://github.com/siemens/cyclonedx-property-taxonomy#readme) |
+| `snyk` | Namespace for use by Snyk. | [Snyk](https://github.com/snyk) | [Snyk Taxonomy Documentation](https://docs.snyk.io/snyk-api-info/get-a-projects-sbom-document-endpoint#custom-cyclonedx-properties) |
+| `sonatype` | Namespace for use by Sonatype | [Sonatype](https://github.com/sonatype) | [Sonatype Taxonomy Documentation](https://help.sonatype.com/lift/open-source-vulnerability-analysis/dependency-view/cyclonedx-sonatype-namespace-taxonomy) |
 | `spack` | Namespace for use by the Spack package manager. | Spack Maintainers | [Spack SBOM Project](https://github.com/spack/spack-sbom#readme) |
-| `stackable` | Namespace for use by Stackable | [Stackable](https://stackable.tech) | `RESERVED` |
-| `syft` | Namespace for use by the Syft project. | Syft Maintainers | [Syft Project](https://github.com/anchore/syft) |
-| `tern` | Namespace for use by the Tern project. | Tern Maintainers | [Tern Project](https://github.com/tern-tools/tern) |
-| `veracode` | Namespace for use by Veracode. | Veracode | [Veracode taxonomy](https://github.com/veracode/cyclonedx-property-taxonomy#readme) |
+| `stackable` | Namespace for use by Stackable | [Stackable](https://github.com/stackabletech) | `RESERVED` |
+| `syft` | Namespace for use by the Syft project. | [Syft Maintainers](https://github.com/anchore/syft) | `RESERVED` |
+| `tern` | Namespace for use by the Tern project. | [Tern Maintainers](https://github.com/tern-tools/tern) | `RESERVED` |
+| `veracode` | Namespace for use by Veracode. | [Veracode](https://github.com/veracod) | [Veracode taxonomy](https://github.com/veracode/cyclonedx-property-taxonomy#readme) |
 
 ## Registering New Top Level Namespaces
 
@@ -93,7 +93,7 @@ It is RECOMMENDED that anyone creating custom properties outside of the `interna
 namespace SHOULD register a new top level namespace.
 
 The process for registering a new top level namespace is to
-[create a new issue requesting it](https://github.com/CycloneDX/cyclonedx-property-taxonomy/issues/new/choose).
+[create a new issue requesting it](https://github.com/CycloneDX/cyclonedx-property-taxonomy/issues/new).
 
 Namespaces are initially registered as `RESERVED`.
 

--- a/cdx.md
+++ b/cdx.md
@@ -8,17 +8,17 @@ _Boolean value_ are `true` or `false`. Case sensitive.
 
 | Namespace | Description | Administered By | Taxonomy |
 | --------- | ----------- | --------------- | -------- |
-| `cdx:composer` | Namespace for properties specific to the PHP Composer ecosystem. | CycloneDX PHP Maintainers | [cdx:composer taxonomy](cdx/composer.md) |
-| `cdx:device` | Namespace for properties specific to hardware devices. | CycloneDX Core Working Group | [cdx:device taxonomy](cdx/device.md) |
-| `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | CycloneDX Go Maintainers | [cdx:gomod taxonomy](cdx/gomod.md) |
-| `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | CycloneDX JavaScript Maintainers | [cdx:npm taxonomy](cdx/npm.md) |
-| `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | CycloneDX Python Maintainers | [cdx:pipenv taxonomy](cdx/pipenv.md) |
-| `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | CycloneDX Python Maintainers | [cdx:poetry taxonomy](cdx/poetry.md) |
+| `cdx:composer` | Namespace for properties specific to the PHP Composer ecosystem. | [CycloneDX PHP Maintainers] | [cdx:composer taxonomy](cdx/composer.md) |
+| `cdx:device` | Namespace for properties specific to hardware devices. | [CycloneDX Core Working Group] | [cdx:device taxonomy](cdx/device.md) |
+| `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | [CycloneDX Go Maintainers] | [cdx:gomod taxonomy](cdx/gomod.md) |
+| `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | [CycloneDX JavaScript Maintainers] | [cdx:npm taxonomy](cdx/npm.md) |
+| `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | [CycloneDX Python Maintainers] | [cdx:pipenv taxonomy](cdx/pipenv.md) |
+| `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | [CycloneDX Python Maintainers] | [cdx:poetry taxonomy](cdx/poetry.md) |
 
 ## Registering `cdx` Namespaces and Properties
 
 The process for registering new `cdx` namespaces and properties is to
-[create a new issue requesting it](https://github.com/CycloneDX/cyclonedx-property-taxonomy/issues/new/choose).
+[create a new issue requesting it](https://github.com/CycloneDX/cyclonedx-property-taxonomy/issues/new).
 
 If you are requesting a new namespace directly under the `cdx` namespace,
 the request will be reviewed by the Core Working Group.
@@ -26,3 +26,9 @@ the request will be reviewed by the Core Working Group.
 If you are requesting a new namespace or property under one of the
 namespaces within `cdx`, it will be reviewed by the team identified in the
 table above.
+
+[CycloneDX Core Working Group]: https://github.com/orgs/CycloneDX/teams/core-team
+[CycloneDX PHP Maintainers]: https://github.com/orgs/CycloneDX/teams/php-maintainers
+[CycloneDX Go Maintainers]: https://github.com/orgs/CycloneDX/teams/go-maintainers
+[CycloneDX Python Maintainers]: https://github.com/orgs/CycloneDX/teams/python-maintainers
+[CycloneDX JavaScript Maintainers]: https://github.com/orgs/CycloneDX/teams/javascript-maintainers


### PR DESCRIPTION
linked the TLN maintainers, based on data from  the original issues, pullrequests and other historical data.