### PR TITLE
Add `cdx:rustc` & `cdx:cargo`  subnamespaces

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -8,13 +8,14 @@ _Boolean value_ are `true` or `false`. Case sensitive.
 
 | Namespace | Description | Administered By | Taxonomy |
 | --------- | ----------- | --------------- | -------- |
+| `cdx:cargo` | Namespace for properties specific to the Rust package manager Cargo. | [CycloneDX Rust Maintainers] | `RESERVED` |
 | `cdx:composer` | Namespace for properties specific to the PHP Composer ecosystem. | [CycloneDX PHP Maintainers] | [cdx:composer taxonomy](cdx/composer.md) |
 | `cdx:device` | Namespace for properties specific to hardware devices. | [CycloneDX Core Working Group] | [cdx:device taxonomy](cdx/device.md) |
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | [CycloneDX Go Maintainers] | [cdx:gomod taxonomy](cdx/gomod.md) |
 | `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | [CycloneDX JavaScript Maintainers] | [cdx:npm taxonomy](cdx/npm.md) |
 | `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | [CycloneDX Python Maintainers] | [cdx:pipenv taxonomy](cdx/pipenv.md) |
 | `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | [CycloneDX Python Maintainers] | [cdx:poetry taxonomy](cdx/poetry.md) |
-| `cdx:rustcmespace for properties specific to the Python Poetry ecosystem. | [CycloneDX Python Maintainers] | [cdx:poetry taxonomy](cdx/poetry.md) |
+| `cdx:rustc` | Namespace for properties specific to the Rust compiler rustc. | [CycloneDX Rust Maintainers] | [cdx:rustc taxonomy](cdx/rustc.md) |
 
 ## Registering `cdx` Namespaces and Properties
 
@@ -33,3 +34,4 @@ table above.
 [CycloneDX Go Maintainers]: https://github.com/orgs/CycloneDX/teams/go-maintainers
 [CycloneDX Python Maintainers]: https://github.com/orgs/CycloneDX/teams/python-maintainers
 [CycloneDX JavaScript Maintainers]: https://github.com/orgs/CycloneDX/teams/javascript-maintainers
+[CycloneDX Rust Maintainers]: https://github.com/orgs/CycloneDX/teams/rust-maintainers

--- a/cdx.md
+++ b/cdx.md
@@ -14,6 +14,7 @@ _Boolean value_ are `true` or `false`. Case sensitive.
 | `cdx:npm` | Namespace for properties specific to the Node NPM ecosystem. | [CycloneDX JavaScript Maintainers] | [cdx:npm taxonomy](cdx/npm.md) |
 | `cdx:pipenv` | Namespace for properties specific to the Python Pipenv ecosystem. | [CycloneDX Python Maintainers] | [cdx:pipenv taxonomy](cdx/pipenv.md) |
 | `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | [CycloneDX Python Maintainers] | [cdx:poetry taxonomy](cdx/poetry.md) |
+| `cdx:rustcmespace for properties specific to the Python Poetry ecosystem. | [CycloneDX Python Maintainers] | [cdx:poetry taxonomy](cdx/poetry.md) |
 
 ## Registering `cdx` Namespaces and Properties
 

--- a/cdx/rustc.md
+++ b/cdx/rustc.md
@@ -2,4 +2,4 @@
 
 | Namespace             | Description                                                       |
 | --------------------- | ----------------------------------------------------------------- |
-| `cdx:gomod:target`    | Property for the target triple (e.g. `x86_64-unknown-linux-gnu`). |
+| `cdx:rustc:target`    | Property for the target triple (e.g. `x86_64-unknown-linux-gnu`). |

--- a/cdx/rustc.md
+++ b/cdx/rustc.md
@@ -1,0 +1,5 @@
+## `cdx:rustc` Namespace Taxonomy
+
+| Namespace             | Description                                                       |
+| --------------------- | ----------------------------------------------------------------- |
+| `cdx:gomod:target`    | Property for the target triple (e.g. `x86_64-unknown-linux-gnu`). |


### PR DESCRIPTION
/fixes #75 

This is up for discussion.
Not sure if we want to make `cdx:rustc:target` a namespace or a property.
Could be `cdx:rustc:target:triple` as well.