### PR TITLE
Update link references of ownership from nexB to aboutcode-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ABNF syntax as per [RFC5234: Augmented BNF for Syntax Specifications: ABNF](http
 
 ## Registered Top Level Namespaces
 
-Regardless of other licensing attributes in this repository or document,
+Regardless of other licensing attributes in this repository or document,  
 the following table (called "registry") is marked with
 <a href="http://creativecommons.org/publicdomain/zero/1.0" style="display:inline-block">
   CC0 1.0

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ABNF syntax as per [RFC5234: Augmented BNF for Syntax Specifications: ABNF](http
 
 ## Registered Top Level Namespaces
 
-Regardless of other licensing attributes in this repository or document,  
+Regardless of other licensing attributes in this repository or document,
 the following table (called "registry") is marked with
 <a href="http://creativecommons.org/publicdomain/zero/1.0" style="display:inline-block">
   CC0 1.0
@@ -82,7 +82,7 @@ the following table (called "registry") is marked with
 | `cdx` | Namespace for official CycloneDX namespaces and properties. Unofficial namespaces and properties MUST NOT be used under the `cdx` namespace. | [CycloneDX Core Working Group](https://github.com/orgs/CycloneDX) | [cdx taxonomy](cdx.md) |
 | `internal` | Namespace for internal use only. BOMs shared with 3rd parties SHOULD NOT include properties in this namespace. | N/A | N/A |
 | `urn` | Namespace blocked to prevent confusions with [Uniform Resource Name](https://datatracker.ietf.org/doc/html/rfc2141) | N/A | N/A |
-| `aboutcode` | Namespace for use by AboutCode projects. | [nexB](https://github.com/nexB) | [AboutCode taxonomy](https://github.com/nexB/aboutcode-cyclonedx-taxonomy#readme) |
+| `aboutcode` | Namespace for use by AboutCode projects. | [AboutCode.org](https://github.com/aboutcode-org) | [AboutCode taxonomy](https://github.com/aboutcode-org/aboutcode-cyclonedx-taxonomy#readme) |
 | `accellence` | Namespace for use by Accellence Technologies. | [AccellenceTechnologies](https://github.com/AccellenceTechnologies) | [Accellence taxonomy](https://github.com/AccellenceTechnologies/cyclonedx-property-taxonomy#readme) |
 | `amazon` | Namespace for use by Amazon. | [Amazon](https://github.com/amzn) | `RESERVED` |
 | `appknox` | Namespace for use by Appknox Platform. | [Appknox](https://github.com/appknox) | [Appknox taxonomy](https://github.com/appknox/cyclonedx-property-taxonomy#readme) |


### PR DESCRIPTION
The `aboutcode` is now under `AboutCode.org`