### PR TITLE
fix some `cdx:python` properties

### DIFF
--- a/cdx/poetry.md
+++ b/cdx/poetry.md
@@ -27,7 +27,7 @@
 
 ## `cdx:poetry:package:source:vcs` Namespace Taxonomy
 
-This namespace is **deprecated** in vavour of the more general [`cdx:python:package:source:vcs`](./python.md).
+This namespace is **deprecated** in favor of the more general [`cdx:python:package:source:vcs`](./python.md).
 
 | Property | Description |
 |----------|-------------|

--- a/cdx/poetry.md
+++ b/cdx/poetry.md
@@ -21,4 +21,17 @@
 | `cdx:poetry:package:source:reference` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 | `cdx:poetry:package:source:resolved_reference` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 
+| Namespace | Description |
+|-----------|-------------|
+| `cdx:poetry:package:source:vcs` | **DEPRECATED** namespace for package-source's VCS specific properties. |
+
+## `cdx:poetry:package:source:vcs` Namespace Taxonomy
+
+This namespace is **deprecated** in vavour of the more general [`cdx:python:package:source:vcs`](./python.md).
+
+| Property | Description |
+|----------|-------------|
+| `cdx:poetry:package:source:vcs:requested_revision` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+| `cdx:poetry:package:source:vcs:commit_id` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+
 [CDX-useCases-externalReferences]: https://cyclonedx.org/use-cases/#external-references

--- a/cdx/poetry.md
+++ b/cdx/poetry.md
@@ -18,7 +18,7 @@
 
 | Property | Description |
 |----------|-------------|
-| `cdx:poetry:package:source:reference` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+| `cdx:poetry:package:source:reference` | The repository reference of this package, e.g. "master", "1.0.0" or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 | `cdx:poetry:package:source:resolved_reference` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 
 | Namespace | Description |
@@ -27,11 +27,11 @@
 
 ## `cdx:poetry:package:source:vcs` Namespace Taxonomy
 
-This namespace is **deprecated** in favor of the more general [`cdx:python:package:source:vcs`](./python.md).
+This namespace is **deprecated** in favor of the more general [`cdx:python:package:source:vcs`](./python.md), or consider the properties mentioned above.
 
 | Property | Description |
 |----------|-------------|
-| `cdx:poetry:package:source:vcs:requested_revision` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+| `cdx:poetry:package:source:vcs:requested_revision` | The repository reference of this package, e.g. "master", "1.0.0" or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 | `cdx:poetry:package:source:vcs:commit_id` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 
 [CDX-useCases-externalReferences]: https://cyclonedx.org/use-cases/#external-references

--- a/cdx/python.md
+++ b/cdx/python.md
@@ -50,7 +50,7 @@ In accordance with [packaging's `direct-url` data structure for VCS](https://pac
 
 | Property | Description |
 |----------|-------------|
-| `cdx:python:package:source:vcs:requested_revision` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+| `cdx:python:package:source:vcs:requested_revision` | The repository reference of this package, e.g. "master", "1.0.0" or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 | `cdx:python:package:source:vcs:commit_id` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 
 ## `cdx:python:package:source:local` Namespace Taxonomy

--- a/cdx/python.md
+++ b/cdx/python.md
@@ -39,6 +39,7 @@ In accordance with [packaging's `direct-url` data structure for Archive](https:/
 
 | Property | Description |
 |----------|-------------|
+| | |
 
 There are no properties regiestered so far.  
 The `hashes` of an archive should be added to the [`ExternalReference`][CDX-useCases-externalReferences] that represents the package source.
@@ -49,8 +50,8 @@ In accordance with [packaging's `direct-url` data structure for VCS](https://pac
 
 | Property | Description |
 |----------|-------------|
-| `cdx:poetry:package:source:vcs:requested_revision` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
-| `cdx:poetry:package:source:vcs:commit_id` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+| `cdx:python:package:source:vcs:requested_revision` | The repository reference of this package, e.g. master, 1.0.0 or a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
+| `cdx:python:package:source:vcs:commit_id` | The resolved repository reference of this package, e.g. a commit hash for git. Values may be applied to [`externalReferences`][CDX-useCases-externalReferences] of type `vcs`. _Non-empty string value_. May appear once. |
 
 ## `cdx:python:package:source:local` Namespace Taxonomy
 


### PR DESCRIPTION
to be backwards-compatible, the "wrong" property names were not removed, but moved where they belong, and were deprecated in favor of the "fixed" ones. 