### PR TITLE
remove docs for TLNamespace `ksoc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ the following table (called "registry") is marked with
 | `hoppr` | Namespace for the use by the Hoppr project. | [Lockheed Martin](https://hoppr.dev) | [Hoppr Taxonomy Documentation](https://hoppr.dev/docs/architecture/cdx-taxonomy) |
 | `ibm` | Namespace for use by IBM. | [IBM](https://github.com/IBM) | `RESERVED` |
 | `interlynk` | Namespace for use by Interlynk. | [Interlynk](https://github.com/interlynk-io) | [Interlynk taxonomy](https://github.com/interlynk-io/cyclonedx-property-taxonomy) |
-| `ksoc` | Namespace for use by KSOC. | [KSOC](https://github.com/ksoclabs) | [KSOC taxonomy](https://github.com/ksoclabs/kbom/blob/main/docs/taxonomy.md) |
+| `ksoc` | Namespace for use by KSOC. | [KSOC](https://github.com/ksoclabs) | `RESERVED` |
 | `medical-aegis` | Namespace for use by Medical Aegis. | [Medical Aegis](https://github.com/Medical-Aegis) | `RESERVED` |
 | `nix` | Namespace for Nix properties. | [Nixpkgs Maintainers](https://github.com/NixOS/nixpkgs/) | [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/unstable/#sec-interop.cylonedx-nix) |
 | `observer` | Namespace for use by SBOM Observer. | [Bitfront](https://github.com/bitfront-se) | [SBOM Observer Taxonomy](https://github.com/bitfront-se/cyclonedx-property-taxonomy) |


### PR DESCRIPTION
<https://github.com/ksoclabs/kbom/blob/main/docs/taxonomy.md> no longer exists.

<https://github.com/ksoclabs/kbom> was moved
> This repo has moved. Please see https://github.com/rad-security/kbom for the permanent home of KBOM.

So the new location would be <https://github.com/rad-security/kbom/blob/main/docs/taxonomy.md>

The problem is: the new target uses a different TopLevel namespace `rad:`.
Therefore, the documentation is outdated and shall be removed. 



