### PR TITLE
add link to published BSI taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ the following table (called "registry") is marked with
 | `appknox` | Namespace for use by Appknox Platform. | [Appknox](https://github.com/appknox) | [Appknox taxonomy](https://github.com/appknox/cyclonedx-property-taxonomy#readme) |
 | `aquasecurity` | Namespace for use by Aqua Security. | [Aqua Security](https://github.com/aquasecurity) | `RESERVED` |
 | `boschrexroth` | Namespace for use by Bosch Rexroth. | [Bosch Rexroth AG](https://github.com/boschrexroth) | [Bosch Rexroth taxonomy](https://github.com/boschrexroth/cyclonedx-property-taxonomy#readme) |
-| `bsi` | Namespace for use by BSI. | [BSI](https://github.com/BSI-Bund) | `RESERVED` |
+| `bsi` | Namespace for use by BSI. | [BSI](https://github.com/BSI-Bund) | [BSI taxonomy](https://github.com/BSI-Bund/tr-03183-cyclonedx-property-taxonomy) |
 | `bytetrail` | Namespace for use by ByteTrail. | [ByteTrail](https://github.com/bytetrail) | `RESERVED` |
 | `codenotary` | Namespace for use by Codenotary platform. | [Codenotary](https://github.com/codenotary) | [Codenotary taxonomy](https://github.com/codenotary/cyclonedx-property-taxonomy#readme) |
 | `contact-software` | Namespace for use by Contact Software. | [Contact Software](https://github.com/cslab) | `RESERVED` |


### PR DESCRIPTION
BSI has just published the first version of its CycloneDX top level namespace taxonomy. Please add the link to it to the table of the Registered Top Level Namespaces