### PR TITLE
namespace `cdx:esbuild`

### DIFF
--- a/cdx.md
+++ b/cdx.md
@@ -18,6 +18,7 @@ _Boolean value_ are `true` or `false`; case sensitive.
 | `cdx:ai-ml` | Namespace for properties specific to the Artificial Intelligence (AI)/machine Learning (ML) technology domain | [CycloneDX Core Working Group] | [cdx:ai-ml taxonomy](cdx/ai-ml.md) |
 | `cdx:composer` | Namespace for properties specific to the PHP Composer ecosystem. | [CycloneDX PHP Maintainers] | [cdx:composer taxonomy](cdx/composer.md) |
 | `cdx:device` | Namespace for properties specific to hardware devices. | [CycloneDX Core Working Group] | [cdx:device taxonomy](cdx/device.md) |
+| `cdx:esbuild` | Namespace for properties specific to the esbuild ecosystem. | [CycloneDX JavaScript Maintainers] | [cdx:esbuild taxonomy](cdx/esbuild.md) |
 | `cdx:gomod` | Namespace for properties specific to the Go Module ecosystem. | [CycloneDX Go Maintainers] | [cdx:gomod taxonomy](cdx/gomod.md) |
 | `cdx:lifecycle` | Namespace for properties specific to component and service lifecycles. | [CycloneDX Core Working Group] | [cdx:lifecycle taxonomy](cdx/lifecycle.md) |
 | `cdx:maven` | Namespace for properties specific to the Maven ecosystem. | [CycloneDX Maven Maintainers] [CycloneDX Gradle Maintainers] | [cdx:maven taxonomy](cdx/maven.md) |

--- a/cdx/esbuild.md
+++ b/cdx/esbuild.md
@@ -9,3 +9,5 @@ The official rules and processes apply - see [parent document](../cdx.md).
 | Property | Description |
 |----------|-------------|
 | `cdx:esbuild:isVirtual` | Whether the component is virtual. _Boolean value_.<br/> If the property is missing, then assume the value to be `false`.<br/> May appear once. |
+
+_Boolean value_ are `true` or `false`; case sensitive.

--- a/cdx/esbuild.md
+++ b/cdx/esbuild.md
@@ -18,4 +18,3 @@ _Boolean value_ are `true` or `false`; case sensitive.
 | Property | Description |
 |----------|-------------|
 | `cdx:esbuild:input:isVirtual` | Whether the input is virtual. _Boolean value_.<br/> If the property is missing, then assume the value to be `false`.<br/> May appear once. |
-

--- a/cdx/esbuild.md
+++ b/cdx/esbuild.md
@@ -6,7 +6,6 @@ The official rules and processes apply - see [parent document](../cdx.md).
 
 ----
 
-
 | Namespace | Description |
 |-----------|-------------|
 | `cdx:esbuild:input` | Namespace for input specific properties. |

--- a/cdx/esbuild.md
+++ b/cdx/esbuild.md
@@ -6,8 +6,16 @@ The official rules and processes apply - see [parent document](../cdx.md).
 
 ----
 
-| Property | Description |
-|----------|-------------|
-| `cdx:esbuild:isVirtual` | Whether the component is virtual. _Boolean value_.<br/> If the property is missing, then assume the value to be `false`.<br/> May appear once. |
+
+| Namespace | Description |
+|-----------|-------------|
+| `cdx:esbuild:input` | Namespace for input specific properties. |
 
 _Boolean value_ are `true` or `false`; case sensitive.
+
+## `cdx:esbuild:input` Namespace Taxonomy
+
+| Property | Description |
+|----------|-------------|
+| `cdx:esbuild:input:isVirtual` | Whether the input is virtual. _Boolean value_.<br/> If the property is missing, then assume the value to be `false`.<br/> May appear once. |
+

--- a/cdx/esbuild.md
+++ b/cdx/esbuild.md
@@ -1,0 +1,11 @@
+# `cdx:esbuild` Namespace Taxonomy
+
+This is the namespace for official CycloneDX properties related to the [esbuild ecosystem](https://esbuild.github.io/).
+
+The official rules and processes apply - see [parent document](../cdx.md).
+
+----
+
+| Property | Description |
+|----------|-------------|
+| `cdx:esbuild:isVirtual` | Whether the component is virtual. _Boolean value_.<br/> If the property is missing, then assume the value to be `false`.<br/> May appear once. |


### PR DESCRIPTION
caused by https://github.com/CycloneDX/cyclonedx-esbuild/pull/143